### PR TITLE
Config files are now loaded via enviroment variables.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>ca.mestevens.java</groupId>
     <artifactId>typesafe-dropwizard-configuration</artifactId>
-    <version>1.2</version>
+    <version>1.3-SNAPSHOT</version>
     <name>Typesafe Dropwizard Configuration</name>
     <description>A way to use typesafe config files as dropwizard configuration files</description>
     <url>https://github.com/mestevens/typesafe-dropwizard-configuration.git</url>
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.6</version>
+            <version>1.18.4</version>
             <scope>provided</scope>
         </dependency>
 
@@ -132,6 +132,13 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!--No longer shipped with Java 11, so we need to include it manually-->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/ca/mestevens/java/configuration/factory/TypesafeConfigurationFactory.java
+++ b/src/main/java/ca/mestevens/java/configuration/factory/TypesafeConfigurationFactory.java
@@ -38,6 +38,8 @@ public class TypesafeConfigurationFactory<T extends TypesafeConfiguration> imple
                 .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
         this.aClass = aClass;
         this.dropwizardConfigName = dropwizardConfigName;
+        // Invalidate any existing caches to ensure we pickup the latest values from the System and Environment
+        ConfigFactory.invalidateCaches();
         this.systemProperties = ConfigFactory.systemProperties();
     }
 

--- a/src/main/java/ca/mestevens/java/configuration/factory/TypesafeConfigurationFactory.java
+++ b/src/main/java/ca/mestevens/java/configuration/factory/TypesafeConfigurationFactory.java
@@ -67,14 +67,13 @@ public class TypesafeConfigurationFactory<T extends TypesafeConfiguration> imple
         this.withOptionalFile(getExecutionDirectory() + "/application.local.conf");
 
         // 4. Look for a matching .env.* files in the resources
-        final String env = systemProperties.getString("env");
-        final String resourceKey = env.isEmpty() ? "application" : env + ".application";
+        final String resourceKey = systemProperties.hasPath("env") ? systemProperties.getString("env") + ".application" : "application";
         this.withResource(resourceKey);
 
 
         // 5. Look for application.conf in resources
         // If we don't pass an environment, then we know that we've already loaded the main application conf
-        if (!env.isEmpty()) {
+        if (!systemProperties.hasPath("env")) {
             this.withResource("application");
         }
 //        final Config config = ConfigFactory.load();

--- a/src/main/java/ca/mestevens/java/configuration/factory/TypesafeConfigurationFactory.java
+++ b/src/main/java/ca/mestevens/java/configuration/factory/TypesafeConfigurationFactory.java
@@ -10,6 +10,8 @@ import io.dropwizard.configuration.ConfigurationException;
 import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.configuration.ConfigurationSourceProvider;
 import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -20,6 +22,8 @@ import static java.util.Objects.requireNonNull;
 
 public class TypesafeConfigurationFactory<T extends TypesafeConfiguration> implements ConfigurationFactory<T> {
 
+    private static final String ENV_KEY = "ENV";
+    private static final Logger logger = LoggerFactory.getLogger(TypesafeConfigurationFactory.class);
     private final ObjectMapper objectMapper;
     private final Class<T> aClass;
     private final String dropwizardConfigName;
@@ -61,12 +65,11 @@ public class TypesafeConfigurationFactory<T extends TypesafeConfiguration> imple
         config = withResource(config, "application");
 
         // 2. Look for a matching .env.* files in the resources
-        final String resourceKey = systemProperties.hasPath("env") ? systemProperties.getString("env") + ".application" : "application";
         // If we don't pass an environment, then we know that we've already loaded the main application conf
-        if (systemProperties.hasPath("env")) {
-            config = withResource(config, resourceKey);
+        final String env = getEnvironmentOverride();
+        if (env != null) {
+            config = withResource(config, env + ".application");
         }
-
         // 3. Look for application.local.conf in the working directory
         config = withOptionalFile(config, getExecutionDirectory() + "/application.local.conf");
 
@@ -84,6 +87,7 @@ public class TypesafeConfigurationFactory<T extends TypesafeConfiguration> imple
         final Config resolvedSubConfig = subConfig.resolve();
         final T typesafeConfiguration = this.objectMapper.readValue(
                 this.objectMapper.writeValueAsString(resolvedSubConfig.root().unwrapped()), aClass);
+        logger.trace("Final config: {}", resolvedSubConfig.root().render());
         typesafeConfiguration.setConfig(resolvedSubConfig);
         return typesafeConfiguration;
     }
@@ -93,17 +97,34 @@ public class TypesafeConfigurationFactory<T extends TypesafeConfiguration> imple
     }
 
     private static Config withOptionalFile(Config config, String path) {
+        logger.debug("Attempting to load optional file at: {}", path);
         final File configFilePath = new File(path);
 
         if (configFilePath.exists()) {
-            return ConfigFactory.parseFile(configFilePath).withFallback(config);
+            logger.debug("Found config file, loading");
+            final Config cfg = ConfigFactory.parseFile(configFilePath);
+            logger.trace(cfg.root().render());
+            return cfg.withFallback(config);
         }
         return config;
     }
 
     private static Config withResource(Config config, String resource) {
+        logger.debug("Appending {} to config", resource);
         final Config resourceConfig = ConfigFactory.parseResourcesAnySyntax(resource);
+        logger.trace(resourceConfig.root().render());
         return resourceConfig.withFallback(config);
+    }
+
+    private String getEnvironmentOverride() {
+        // Look to see if $ENV or -DENV is set, biasing towards the environment variable
+        if (System.getenv(ENV_KEY) != null)
+                return System.getenv(ENV_KEY);
+
+        if (systemProperties.hasPath(ENV_KEY) && !systemProperties.getString(ENV_KEY).equals(""))
+            return systemProperties.getString(ENV_KEY);
+
+        return null;
     }
 
 

--- a/src/test/java/ca/mestevens/java/configuration/ConfigurationOverrideTest.java
+++ b/src/test/java/ca/mestevens/java/configuration/ConfigurationOverrideTest.java
@@ -1,0 +1,157 @@
+package ca.mestevens.java.configuration;
+
+import ca.mestevens.java.UnitTest;
+import ca.mestevens.java.configuration.factory.TypesafeConfigurationFactory;
+import ch.qos.logback.classic.Level;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.typesafe.config.ConfigFactory;
+import io.dropwizard.jackson.DiscoverableSubtypeResolver;
+import io.dropwizard.jackson.LogbackModule;
+import io.dropwizard.jetty.ConnectorFactory;
+import io.dropwizard.jetty.HttpConnectorFactory;
+import io.dropwizard.logging.DefaultLoggingFactory;
+import io.dropwizard.server.DefaultServerFactory;
+import lombok.SneakyThrows;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.List;
+import java.util.Map;
+
+@Category(UnitTest.class)
+public class ConfigurationOverrideTest {
+
+    private ObjectMapper objectMapper;
+    private TypesafeConfigurationFactory typesafeConfiguration;
+
+    @Before
+    public void setUp() {
+        // Clear the environment variables
+        System.clearProperty("logging.level");
+        System.clearProperty("env");
+        this.objectMapper = new ObjectMapper()
+                .registerModule(new GuavaModule())
+                .registerModule(new LogbackModule())
+                .setSubtypeResolver(new DiscoverableSubtypeResolver());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testFileOverrides() {
+        System.setProperty("env", "test");
+        // We need this here to tell the ConfigFactory to reload the system and environment variables
+        ConfigFactory.invalidateCaches();
+        this.typesafeConfiguration = new TypesafeConfigurationFactory<>(objectMapper, TypesafeConfiguration.class, null);
+
+        final TypesafeConfiguration configuration = typesafeConfiguration.build();
+
+        //Server
+        final DefaultServerFactory defaultServerFactory = (DefaultServerFactory) configuration.getServerFactory();
+        final List<ConnectorFactory> connectorFactories = defaultServerFactory.getApplicationConnectors();
+        Assert.assertEquals(1, connectorFactories.size());
+        Assert.assertTrue(connectorFactories
+                .stream()
+                .map(connectorFactory -> (HttpConnectorFactory) connectorFactory)
+                .anyMatch(httpConnectorFactory -> httpConnectorFactory.getPort() == 4433));
+
+        final List<ConnectorFactory> adminConnectorFactories = defaultServerFactory.getAdminConnectors();
+        Assert.assertEquals(1, adminConnectorFactories.size());
+        Assert.assertTrue(adminConnectorFactories
+                .stream()
+                .map(connectorFactory -> (HttpConnectorFactory) connectorFactory)
+                .anyMatch(httpConnectorFactory -> httpConnectorFactory.getPort() == 9191));
+
+        // Check logging
+        final DefaultLoggingFactory defaultLoggingFactory = (DefaultLoggingFactory) configuration.getLoggingFactory();
+        final Map<String, JsonNode> loggers = defaultLoggingFactory.getLoggers();
+        Assert.assertEquals(5, loggers.size());
+        Assert.assertTrue(loggers.keySet().contains("io.dropwizard"));
+        Assert.assertEquals("test", loggers.get("io.dropwizard").asText());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testEnivornmentOverrides() {
+        System.setProperty("env", "test");
+        System.setProperty("logging.level", "TRACE");
+        ConfigFactory.invalidateCaches();
+        this.typesafeConfiguration = new TypesafeConfigurationFactory<>(objectMapper, TypesafeConfiguration.class, null);
+
+        final TypesafeConfiguration configuration = typesafeConfiguration.build();
+
+        //Server
+        final DefaultServerFactory defaultServerFactory = (DefaultServerFactory) configuration.getServerFactory();
+        final List<ConnectorFactory> connectorFactories = defaultServerFactory.getApplicationConnectors();
+        Assert.assertEquals(1, connectorFactories.size());
+        Assert.assertTrue(connectorFactories
+                .stream()
+                .map(connectorFactory -> (HttpConnectorFactory) connectorFactory)
+                .anyMatch(httpConnectorFactory -> httpConnectorFactory.getPort() == 4433));
+
+        final List<ConnectorFactory> adminConnectorFactories = defaultServerFactory.getAdminConnectors();
+        Assert.assertEquals(1, adminConnectorFactories.size());
+        Assert.assertTrue(adminConnectorFactories
+                .stream()
+                .map(connectorFactory -> (HttpConnectorFactory) connectorFactory)
+                .anyMatch(httpConnectorFactory -> httpConnectorFactory.getPort() == 9191));
+
+        // Check logging
+        final DefaultLoggingFactory defaultLoggingFactory = (DefaultLoggingFactory) configuration.getLoggingFactory();
+        final Map<String, JsonNode> loggers = defaultLoggingFactory.getLoggers();
+        Assert.assertEquals(5, loggers.size());
+        Assert.assertTrue(loggers.keySet().contains("io.dropwizard"));
+        Assert.assertEquals("test", loggers.get("io.dropwizard").asText());
+        Assert.assertEquals(Level.TRACE, defaultLoggingFactory.getLevel());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testSubConfigOverride() {
+        this.typesafeConfiguration = new TypesafeConfigurationFactory<>(objectMapper, TypesafeConfiguration.class, "subConfig");
+        final TypesafeConfiguration configuration = typesafeConfiguration.build();
+        final DefaultLoggingFactory defaultLoggingFactory = (DefaultLoggingFactory) configuration.getLoggingFactory();
+        Assert.assertEquals(Level.INFO, defaultLoggingFactory.getLevel());
+
+        //Metrics
+        Assert.assertEquals(420, configuration.getMetricsFactory().getFrequency().toSeconds());
+
+    }
+
+    @Test
+    @SneakyThrows
+    public void testNoFileOverridesWithEnvironment() {
+        System.setProperty("logging.level", "TRACE");
+        ConfigFactory.invalidateCaches();
+        this.typesafeConfiguration = new TypesafeConfigurationFactory<>(objectMapper, TypesafeConfiguration.class, null);
+
+        final TypesafeConfiguration configuration = typesafeConfiguration.build();
+
+        //Server
+        final DefaultServerFactory defaultServerFactory = (DefaultServerFactory) configuration.getServerFactory();
+        final List<ConnectorFactory> connectorFactories = defaultServerFactory.getApplicationConnectors();
+        Assert.assertEquals(1, connectorFactories.size());
+        Assert.assertTrue(connectorFactories
+                .stream()
+                .map(connectorFactory -> (HttpConnectorFactory) connectorFactory)
+                .anyMatch(httpConnectorFactory -> httpConnectorFactory.getPort() == 8765));
+
+        final List<ConnectorFactory> adminConnectorFactories = defaultServerFactory.getAdminConnectors();
+        Assert.assertEquals(1, adminConnectorFactories.size());
+        Assert.assertTrue(adminConnectorFactories
+                .stream()
+                .map(connectorFactory -> (HttpConnectorFactory) connectorFactory)
+                .anyMatch(httpConnectorFactory -> httpConnectorFactory.getPort() == 8081));
+
+        // Check logging
+        final DefaultLoggingFactory defaultLoggingFactory = (DefaultLoggingFactory) configuration.getLoggingFactory();
+        final Map<String, JsonNode> loggers = defaultLoggingFactory.getLoggers();
+        Assert.assertEquals(5, loggers.size());
+        Assert.assertTrue(loggers.keySet().contains("io.dropwizard"));
+        Assert.assertEquals("debug", loggers.get("io.dropwizard").asText());
+        Assert.assertEquals(Level.TRACE, defaultLoggingFactory.getLevel());
+    }
+}

--- a/src/test/java/ca/mestevens/java/configuration/ConfigurationOverrideTest.java
+++ b/src/test/java/ca/mestevens/java/configuration/ConfigurationOverrideTest.java
@@ -32,7 +32,7 @@ public class ConfigurationOverrideTest {
     public void setUp() {
         // Clear the environment variables
         System.clearProperty("logging.level");
-        System.clearProperty("env");
+        System.clearProperty("ENV");
         this.objectMapper = new ObjectMapper()
                 .registerModule(new GuavaModule())
                 .registerModule(new LogbackModule())
@@ -42,7 +42,7 @@ public class ConfigurationOverrideTest {
     @Test
     @SneakyThrows
     public void testFileOverrides() {
-        System.setProperty("env", "test");
+        System.setProperty("ENV", "test");
         // We need this here to tell the ConfigFactory to reload the system and environment variables
         ConfigFactory.invalidateCaches();
         this.typesafeConfiguration = new TypesafeConfigurationFactory<>(objectMapper, TypesafeConfiguration.class, null);
@@ -76,7 +76,7 @@ public class ConfigurationOverrideTest {
     @Test
     @SneakyThrows
     public void testEnivornmentOverrides() {
-        System.setProperty("env", "test");
+        System.setProperty("ENV", "test");
         System.setProperty("logging.level", "TRACE");
         ConfigFactory.invalidateCaches();
         this.typesafeConfiguration = new TypesafeConfigurationFactory<>(objectMapper, TypesafeConfiguration.class, null);

--- a/src/test/java/ca/mestevens/java/configuration/ConfigurationOverrideTest.java
+++ b/src/test/java/ca/mestevens/java/configuration/ConfigurationOverrideTest.java
@@ -11,6 +11,7 @@ import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.jackson.LogbackModule;
 import io.dropwizard.jetty.ConnectorFactory;
 import io.dropwizard.jetty.HttpConnectorFactory;
+import io.dropwizard.jetty.HttpsConnectorFactory;
 import io.dropwizard.logging.DefaultLoggingFactory;
 import io.dropwizard.server.DefaultServerFactory;
 import lombok.SneakyThrows;
@@ -43,9 +44,8 @@ public class ConfigurationOverrideTest {
     @SneakyThrows
     public void testFileOverrides() {
         System.setProperty("ENV", "test");
-        // We need this here to tell the ConfigFactory to reload the system and environment variables
-        ConfigFactory.invalidateCaches();
         this.typesafeConfiguration = new TypesafeConfigurationFactory<>(objectMapper, TypesafeConfiguration.class, null);
+
 
         final TypesafeConfiguration configuration = typesafeConfiguration.build();
 
@@ -75,10 +75,9 @@ public class ConfigurationOverrideTest {
 
     @Test
     @SneakyThrows
-    public void testEnivornmentOverrides() {
+    public void testEnvironmentOverrides() {
         System.setProperty("ENV", "test");
         System.setProperty("logging.level", "TRACE");
-        ConfigFactory.invalidateCaches();
         this.typesafeConfiguration = new TypesafeConfigurationFactory<>(objectMapper, TypesafeConfiguration.class, null);
 
         final TypesafeConfiguration configuration = typesafeConfiguration.build();
@@ -89,7 +88,7 @@ public class ConfigurationOverrideTest {
         Assert.assertEquals(1, connectorFactories.size());
         Assert.assertTrue(connectorFactories
                 .stream()
-                .map(connectorFactory -> (HttpConnectorFactory) connectorFactory)
+                .map(connectorFactory -> (HttpsConnectorFactory) connectorFactory)
                 .anyMatch(httpConnectorFactory -> httpConnectorFactory.getPort() == 4433));
 
         final List<ConnectorFactory> adminConnectorFactories = defaultServerFactory.getAdminConnectors();

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+subConfig.logging.level = INFO
+subConfig.metrics.frequency = 7m

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -1,0 +1,39 @@
+subConfig {
+  logging {
+    level = DEBUG
+  }
+
+  server {
+    applicationConnectors = [{
+      type = http
+      port = 8198
+    }]
+  }
+}
+
+logging {
+  level = INFO
+  loggers = {
+    "io.dropwizard" = "debug"
+    "org.eclipse.jetty" = "warn"
+    "com.amazonaws" = "warn"
+    "io.netty" = "warn"
+    "org.apache.http" = "warn"
+  }
+  appenders = [{
+    type = "console"
+    timeZone = "utc"
+    logFormat = "%d{yyyy-MM-dd'T'HH:mm:ssXXX, UTC} %-5level [%thread] %logger{36} - %msg%n"
+  }]
+}
+
+server {
+  applicationConnectors = [{
+    type = http
+    port = 8765
+  }]
+}
+
+metrics {
+  frequency = 5m
+}

--- a/src/test/resources/test.application.json
+++ b/src/test/resources/test.application.json
@@ -1,0 +1,21 @@
+{
+  "logging": {
+    "loggers": {
+      "io.dropwizard": "test"
+    }
+  },
+  "server": {
+    "applicationConnectors": [
+      {
+        "type": "https",
+        "port": "4433"
+      }
+    ],
+    "adminConnectors": [
+      {
+        "type": "http",
+        "port": "9191"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
First off, thanks for your work on a great library! This is a proposed set of changes that modifies the way config files and loaded and merged at runtime.

Starting the server with no config arguments causes the application to look for an `application.local.conf` file in the current working directory, followed any application files in the resources folder. In addition, it adds any command line and environment variables to the config, with a higher priority than the config files.

Existing behavior is still preserved when manually specifying a config file, no auto-loading or config merging is performed.

This only a partial PR, tests still need to be written, but the hope is to gauge your interest in accepting these changes. I've also modified the POM to fix some compilation issues under Java 11. Thanks!